### PR TITLE
Edit - Fixing Bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@800&display=swap" rel="stylesheet">
     <title>Landing Screen</title>
+    <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
+    <script src="script.js"></script>
 </head>
 <body>
     <div class="container">

--- a/script.js
+++ b/script.js
@@ -1,0 +1,46 @@
+$(document).ready( function() {
+    $(".title").on("mouseenter", function() {
+        $(".whole").addClass("img-fit");
+    });
+
+    $(".t1").on("mouseenter", function() {
+        $(".whole").css("backgroundImage", "url('images/p-helias.jpg')");
+    });
+    
+    $(".t2").on("mouseenter", function() {
+        $(".whole").css("backgroundImage", "url('images/p-snooze.jpg')");
+    });
+
+    $(".t3").on("mouseenter", function() {
+        $(".whole").css("backgroundImage", "url('images/p-betches.jpg')");
+    });
+
+    $(".t4").on("mouseenter", function() {
+        $(".whole").css("backgroundImage", "url('images/p-allpro.jpg')");
+    });
+
+    $(".t5").on("mouseenter", function() {
+        $(".whole").css("backgroundImage", "url('images/p-cornerstone.jpg')");
+    });
+
+    $(".t6").on("mouseenter", function() {
+        $(".whole").css("backgroundImage", "url('images/p-taylor.jpg')");
+    });
+
+    $(".t7").on("mouseenter", function() {
+        $(".whole").css("backgroundImage", "url('images/p-modernmd.jpg')");
+    });
+
+    $(".t8").on("mouseenter", function() {
+        $(".whole").css("backgroundImage", "url('images/p-storyverse.jpg')");
+    });
+
+    $(".t9").on("mouseenter", function() {
+        $(".whole").css("backgroundImage", "url('images/p-gts.jpg')");
+    });
+
+    $(".t10").on("mouseenter", function() {
+        $(".whole").css("backgroundImage", "url('images/p-hennessey.jpg')");
+    });
+});
+

--- a/style.css
+++ b/style.css
@@ -21,7 +21,6 @@
 }
 
 .whole {
-    background-image: linear-gradient(#2c3e50, #bdc3c7);
     position: fixed;
     top: 0;
     left: 0;
@@ -81,50 +80,10 @@
     font-size: 11rem;
 }
 
-.title:hover ~ .whole {
+.img-fit {
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
-}
-
-.t1:hover ~ .whole {
-    background-image: url("images/p-helias.jpg");    
-}
-
-.t2:hover ~ .whole {
-    background-image: url("images/p-snooze.jpg");    
-}
-
-.t3:hover ~ .whole {
-    background-image: url("images/p-betches.jpg");    
-}
-
-.t4:hover ~ .whole {
-    background-image: url("images/p-allpro.jpg");    
-}
-
-.t5:hover ~ .whole {
-    background-image: url("images/p-cornerstone.jpg");    
-}
-
-.t6:hover ~ .whole {
-    background-image: url("images/p-taylor.jpg");    
-}
-
-.t7:hover ~ .whole {
-    background-image: url("images/p-modernmd.jpg");    
-}
-
-.t8:hover ~ .whole {
-    background-image: url("images/p-storyverse.jpg");    
-}
-
-.t9:hover ~ .whole {
-    background-image: url("images/p-gts.jpg");    
-}
-
-.t10:hover ~ .whole {
-    background-image: url("images/p-hennessey.jpg");    
 }
 
 footer {


### PR DESCRIPTION
Earlier, there was a bug in which after un-hovering from a title to a non-title location, the doors started closing, and the background image was not retained, instead, a default gray gradient appeared. 
In the edit, I have removed all `background-image` related `:hover` psuedo classes in the **CSS** file and created a **Js** file in which the `background-image` and its fitting is altered on `mouseenter`. That way, the background image is retained as the doors close, and there is no awkward gray gradient.